### PR TITLE
rest_server: add multi-endpoint REST server with logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # exclude
+tags
 *.log
 *.guess
 .in

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,41 @@
-
 # Variables
 CC = gcc
-CFLAGS = -I./include/
-LIBS = -lmicrohttpd -lpthread -lcjson -ltaos
+CFLAGS = -I./include -DCURRENT_LOG_LEVEL=LOG_LEVEL_DEBUG
+LIBS = -lmicrohttpd -lcjson -lpthread
 
 # Directories
 SRC_DIR = src
 BIN_DIR = bin
 
 # Source and object files
-SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/thread.c
+SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c
 OBJS = $(patsubst $(SRC_DIR)/%.c, $(BIN_DIR)/%.o, $(SRCS))
 
 # Target executable
-TARGET = $(BIN_DIR)/data_collector
-
-# Docker image name and version
-DOCKER_IMAGE = data_collector
-DOCKER_VERSION = $(shell cat VERSION)
-DOCKER_TAG = $(DOCKER_IMAGE):$(DOCKER_VERSION)
+TARGET = $(BIN_DIR)/iot_connector
 
 # Default rule
 all: $(BIN_DIR) $(TARGET)
 
 # Build target
 $(TARGET): $(OBJS)
-	$(CC) $(OBJS) $(LDFLAGS) $(LIBS) -o $@
+	$(CC) $(OBJS) $(LIBS) -o $@
 
 # Build object files
 $(BIN_DIR)/%.o: $(SRC_DIR)/%.c | $(BIN_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-# Create bin directory
+# Create bin directory if it doesn't exist
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
-# Build Docker image with version
-docker:
-	docker build -t $(DOCKER_TAG) .
-
 # Clean up build files
 clean:
-	rm -rf $(BIN_DIR) $(TARGET)
+	rm -rf $(BIN_DIR)
 
 # Run the binary
 run: $(TARGET)
 	./$(TARGET)
-.PHONY: all clean docker
+
+.PHONY: all clean run
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # opcua_connector
+
+sudo dnf install opcua library
+sudo dnf install libmicrohttpd-devel
+sudo dnf install cJSON-devel
+sudo dnf install rsyslog
+
+CURRENT_LOG_LEVEL = LOG_LEVEL_DEBUG
+This is the lowest level, so everything will print:
+    ✅ log_debug()
+    ✅ log_info()
+    ✅ log_warn()
+    ✅ log_error()
+CURRENT_LOG_LEVEL = LOG_LEVEL_INFO
+This disables debug, allows the rest:
+    ❌ log_debug() — not shown
+    ✅ log_info()
+    ✅ log_warn()
+    ✅ log_error()
+CURRENT_LOG_LEVEL = LOG_LEVEL_WARN
+    ❌ log_debug()
+    ❌ log_info()
+    ✅ log_warn()
+    ✅ log_error()
+CURRENT_LOG_LEVEL = LOG_LEVEL_ERROR
+    ❌ log_debug()
+    ❌ log_info()
+    ❌ log_warn()
+    ✅ log_error()
+
+✅ If You Want to Log to a File (like /var/log/iot_connector.log)
+
+If you want a traditional text file in /var/log, here’s how to do it:
+🔧 Step 1: Create a rsyslog rule
+
+Create a new file:
+
+sudo vi /etc/rsyslog.d/iot_connector.conf
+
+Paste this content:
+
+if $programname == 'iot_connector' then /var/log/iot_connector.log
+& stop
+
+🔧 Step 2: Restart rsyslog
+
+sudo systemctl restart rsyslog
+
+✅ Step 3: Check log file
+
+Now run your app, and then check:
+
+tail -f /var/log/iot_connector.log
+
+You’ll see the same logs appear there.
+
+
+
+# Debug
+journalctl -t iot_connector -f
+
+# User input
+curl -X POST http://localhost:8080/deviceconfigure   -H "Content-Type: application/json"   -d '{"device_name":"cnc_device_001","opcua":{"endpoint_url":"opc.tcp://192.168.1.100:4840","username":"opcuser","password":"opcpass"},"mqtt":{"broker_url":"mqtts://broker.example.com:8883","username":"mqttuser","password":"mqttpass","publish_interval_ms":1000,"base_topic":"factory/cnc/device001","tls_enabled":true,"certificate_path":"/tmp/device001-cert.pem","certificate_content":"-----BEGIN CERTIFICATE-----\nMIID...END CERTIFICATE-----"}}'

--- a/docs/sample_payload/config.json
+++ b/docs/sample_payload/config.json
@@ -1,0 +1,19 @@
+{
+  "device_name": "cnc_device_001",
+  "opcua": {
+    "endpoint_url": "opc.tcp://192.168.1.100:4840",
+    "username": "opcuser",
+    "password": "opcpass"
+  },
+  "mqtt": {
+    "broker_url": "mqtts://broker.example.com:8883",
+    "username": "mqttuser",
+    "password": "mqttpass",
+    "publish_interval_ms": 1000,
+    "base_topic": "factory/cnc/device001",
+    "tls_enabled": true,
+    "certificate_path": "/etc/mqtt/certs/device001-cert.pem",
+    "certificate_content": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgI...YourCAHere...\n-----END CERTIFICATE-----"
+  }
+}
+

--- a/docs/sample_payload/datapoints.json
+++ b/docs/sample_payload/datapoints.json
@@ -1,0 +1,20 @@
+{
+  "data_points": [
+    {
+      "nodeid": "ns=3;i=1001",
+      "datatype": "int32",
+      "alias": "spindle_speed"
+    },
+    {
+      "nodeid": "ns=3;i=1002",
+      "datatype": "float",
+      "alias": "motor_temp"
+    },
+    {
+      "nodeid": "ns=3;i=1003",
+      "datatype": "boolean",
+      "alias": "alarm_status"
+    }
+  ]
+}
+

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -1,0 +1,29 @@
+#ifndef DEVICE_CONFIG_H
+#define DEVICE_CONFIG_H
+
+typedef struct {
+    char endpoint_url[256];
+    char username[64];
+    char password[64];
+} OPCUAConfig;
+
+typedef struct {
+    char broker_url[256];
+    char username[64];
+    char password[64];
+    int publish_interval_ms;
+    char base_topic[128];
+    int tls_enabled;
+    char certificate_path[256];
+} MQTTConfig;
+
+typedef struct {
+    char device_name[128];
+    OPCUAConfig opcua;
+    MQTTConfig mqtt;
+} DeviceConfig;
+
+extern DeviceConfig g_device_config;
+
+#endif // DEVICE_CONFIG_H
+

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -1,0 +1,8 @@
+#ifndef JSON_UTILS_H
+#define JSON_UTILS_H
+
+#include "log_utils.h"
+int process_json_payload(const char *json);
+
+#endif
+

--- a/include/log_utils.h
+++ b/include/log_utils.h
@@ -1,0 +1,36 @@
+#ifndef LOG_UTILS_H
+#define LOG_UTILS_H
+
+#include <syslog.h>
+
+#define LOG_LEVEL_DEBUG 0
+#define LOG_LEVEL_INFO  1
+#define LOG_LEVEL_WARN  2
+#define LOG_LEVEL_ERROR 3
+
+
+// Allow setting from -DCURRENT_LOG_LEVEL=LOG_LEVEL_INFO, etc.
+#ifndef CURRENT_LOG_LEVEL
+#define CURRENT_LOG_LEVEL LOG_LEVEL_DEBUG //Default Log Level
+#endif
+
+#define log_debug(fmt, ...) \
+    do { if (CURRENT_LOG_LEVEL <= LOG_LEVEL_DEBUG) syslog(LOG_DEBUG, fmt, ##__VA_ARGS__); } while (0)
+
+#define log_info(fmt, ...) \
+    do { if (CURRENT_LOG_LEVEL <= LOG_LEVEL_INFO) syslog(LOG_INFO, fmt, ##__VA_ARGS__); } while (0)
+
+#define log_warn(fmt, ...) \
+    do { if (CURRENT_LOG_LEVEL <= LOG_LEVEL_WARN) syslog(LOG_WARNING, fmt, ##__VA_ARGS__); } while (0)
+
+#define log_error(fmt, ...) \
+    do { if (CURRENT_LOG_LEVEL <= LOG_LEVEL_ERROR) syslog(LOG_ERR, fmt, ##__VA_ARGS__); } while (0)
+
+/*
+#define log_info(fmt, ...)    syslog(LOG_INFO, fmt, ##__VA_ARGS__)
+#define log_debug(fmt, ...)   syslog(LOG_DEBUG, fmt, ##__VA_ARGS__)
+#define log_warn(fmt, ...)    syslog(LOG_WARNING, fmt, ##__VA_ARGS__)
+#define log_error(fmt, ...)   syslog(LOG_ERR, fmt, ##__VA_ARGS__)
+*/
+
+#endif

--- a/include/rest_server.h
+++ b/include/rest_server.h
@@ -1,0 +1,28 @@
+#ifndef REST_SERVER_H
+#define REST_SERVER_H
+
+#include "log_utils.h"
+#include <microhttpd.h>
+#define POST_PORT 8080
+
+enum MHD_Result handle_post_request(
+                void *cls,
+                struct MHD_Connection *connection,
+                const char *url,
+                const char *method,
+                const char *version,
+                const char *upload_data,
+                size_t *upload_data_size,
+                void **con_cls);
+/*int handle_get_request(void *cls, struct MHD_Connection *connection,
+                       const char *url, const char *method,
+                       const char *version, const char *upload_data,
+                       size_t *upload_data_size, void **con_cls);
+
+int handle_del_request(void *cls, struct MHD_Connection *connection,
+                       const char *url, const char *method,
+                       const char *version, const char *upload_data,
+                       size_t *upload_data_size, void **con_cls);
+*/
+#endif
+

--- a/src/json_utils.c
+++ b/src/json_utils.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <cjson/cJSON.h>
+#include "device_config.h"
+#include "log_utils.h"
+
+DeviceConfig g_device_config = {0};  // Zero-initialize
+				     //
+int write_cert_to_file(const char *path, const char *content) {
+    FILE *fp = fopen(path, "w");
+    if (!fp) {
+        syslog(LOG_ERR, "Failed to open cert file: %s", path);
+        return -1;
+    }
+    fputs(content, fp);
+    fclose(fp);
+    syslog(LOG_INFO, "Certificate written to: %s", path);
+    return 0;
+}
+
+void log_device_config(const DeviceConfig *config) {
+    log_debug("Device Name        : %s", config->device_name);
+
+    log_debug("OPCUA Endpoint     : %s", config->opcua.endpoint_url);
+    log_debug("OPCUA Username     : %s", config->opcua.username);
+    log_debug("OPCUA Password     : %s", config->opcua.password);  // Mask if needed
+
+    log_debug("MQTT Broker URL    : %s", config->mqtt.broker_url);
+    log_debug("MQTT Username      : %s", config->mqtt.username);
+    log_debug("MQTT Password      : %s", config->mqtt.password);   // Mask if needed
+    log_debug("MQTT Interval (ms) : %d", config->mqtt.publish_interval_ms);
+    log_debug("MQTT Base Topic    : %s", config->mqtt.base_topic);
+    log_debug("MQTT TLS Enabled   : %s", config->mqtt.tls_enabled ? "true" : "false");
+    log_debug("MQTT Cert Path     : %s", config->mqtt.certificate_path);
+}
+
+int process_json_payload(const char *json) {
+	cJSON *root = cJSON_Parse(json);
+	if (!root) {
+		log_error("INVALID JSON");
+		return -1;
+	}
+
+	cJSON *device_name = cJSON_GetObjectItem(root, "device_name");
+	cJSON *opcua = cJSON_GetObjectItem(root, "opcua");
+	cJSON *mqtt = cJSON_GetObjectItem(root, "mqtt");
+
+	if (!cJSON_IsString(device_name) || !cJSON_IsObject(opcua) || !cJSON_IsObject(mqtt)) {
+		syslog(LOG_ERR, "Missing or invalid main fields");
+		cJSON_Delete(root);
+		return -1;
+	}
+
+	if (!cJSON_IsString(device_name)) goto cleanup;
+	strncpy(g_device_config.device_name, device_name->valuestring, sizeof(g_device_config.device_name) - 1);
+
+	// OPC UA
+	cJSON *endpoint_url = cJSON_GetObjectItem(opcua, "endpoint_url");
+	cJSON *opc_user = cJSON_GetObjectItem(opcua, "username");
+	cJSON *opc_pass = cJSON_GetObjectItem(opcua, "password");
+
+	if (cJSON_IsString(endpoint_url)) strncpy(g_device_config.opcua.endpoint_url, endpoint_url->valuestring, sizeof(g_device_config.opcua.endpoint_url) - 1);
+	if (cJSON_IsString(opc_user)) strncpy(g_device_config.opcua.username, opc_user->valuestring, sizeof(g_device_config.opcua.username) - 1);
+	if (cJSON_IsString(opc_pass)) strncpy(g_device_config.opcua.password, opc_pass->valuestring, sizeof(g_device_config.opcua.password) - 1);
+
+	// MQTT
+	cJSON *broker_url = cJSON_GetObjectItem(mqtt, "broker_url");
+	cJSON *mqtt_user = cJSON_GetObjectItem(mqtt, "username");
+	cJSON *mqtt_pass = cJSON_GetObjectItem(mqtt, "password");
+	cJSON *interval = cJSON_GetObjectItem(mqtt, "publish_interval_ms");
+	cJSON *base_topic = cJSON_GetObjectItem(mqtt, "base_topic");
+	cJSON *tls_enabled = cJSON_GetObjectItem(mqtt, "tls_enabled");
+	cJSON *cert_path = cJSON_GetObjectItem(mqtt, "certificate_path");
+	cJSON *cert_content = cJSON_GetObjectItem(mqtt, "certificate_content");
+
+	if (cJSON_IsString(broker_url)) strncpy(g_device_config.mqtt.broker_url, broker_url->valuestring, sizeof(g_device_config.mqtt.broker_url) - 1);
+	if (cJSON_IsString(mqtt_user)) strncpy(g_device_config.mqtt.username, mqtt_user->valuestring, sizeof(g_device_config.mqtt.username) - 1);
+	if (cJSON_IsString(mqtt_pass)) strncpy(g_device_config.mqtt.password, mqtt_pass->valuestring, sizeof(g_device_config.mqtt.password) - 1);
+	if (cJSON_IsNumber(interval)) g_device_config.mqtt.publish_interval_ms = interval->valueint;
+	if (cJSON_IsString(base_topic)) strncpy(g_device_config.mqtt.base_topic, base_topic->valuestring, sizeof(g_device_config.mqtt.base_topic) - 1);
+	if (cJSON_IsBool(tls_enabled)) g_device_config.mqtt.tls_enabled = tls_enabled->valueint;
+	if (cJSON_IsString(cert_path)) strncpy(g_device_config.mqtt.certificate_path, cert_path->valuestring, sizeof(g_device_config.mqtt.certificate_path) - 1);
+
+	// Write cert to file
+	if (cJSON_IsString(cert_content)) {
+		write_cert_to_file(g_device_config.mqtt.certificate_path, cert_content->valuestring);
+	}
+
+	log_device_config(&g_device_config);	//optional for debug log
+
+	cJSON_Delete(root);
+	return 0;
+
+cleanup:
+	cJSON_Delete(root);
+	return -1;
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <syslog.h>
+#include <signal.h>
+#include <unistd.h>
+#include "rest_server.h"
+
+static volatile int running = 1;
+
+void handle_signal(int sig) {
+    running = 0;
+}
+
+int main() {
+	openlog("iot_connector", LOG_PID | LOG_CONS, LOG_USER);
+	log_info("Starting IoT connector server...");
+	signal(SIGINT, handle_signal);
+
+	struct MHD_Daemon *daemon_post = MHD_start_daemon(
+			MHD_USE_SELECT_INTERNALLY, POST_PORT, NULL, NULL,
+			&handle_post_request, NULL, MHD_OPTION_END);
+	if (!daemon_post) {
+		syslog(LOG_ERR, "Failed to start POST server");
+		return 1;
+	}
+	log_info("POST server running on port %d", POST_PORT);
+/*
+	struct MHD_Daemon *daemon_get = MHD_start_daemon(
+			MHD_USE_SELECT_INTERNALLY, GET_PORT, NULL, NULL,
+			&handle_get_request, NULL, MHD_OPTION_END);
+	if (!daemon_get) {
+		syslog(LOG_ERR, "Failed to start GET server");
+		MHD_stop_daemon(daemon_post);
+		return 1;
+	}
+	log_info("GET server running on port %d", GET_PORT);
+
+	struct MHD_Daemon *daemon_del = MHD_start_daemon(
+			MHD_USE_SELECT_INTERNALLY, DEL_PORT, NULL, NULL,
+			&handle_del_request, NULL, MHD_OPTION_END);
+	if (!daemon_del) {
+		syslog(LOG_ERR, "Failed to start DELETE server");
+		MHD_stop_daemon(daemon_post);
+		MHD_stop_daemon(daemon_get);
+		return 1;
+	}
+	log_info("DELETE server running on port %d", DEL_PORT);
+*/
+	// Run until Ctrl+C
+	while (running) {
+		sleep(1);
+	}
+
+	log_info("Shutting down servers...");
+	MHD_stop_daemon(daemon_post);
+//	MHD_stop_daemon(daemon_get);
+//	MHD_stop_daemon(daemon_del);
+
+	closelog();
+	return 0;
+}
+

--- a/src/rest_server.c
+++ b/src/rest_server.c
@@ -1,0 +1,98 @@
+#include <microhttpd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <syslog.h>
+#include "json_utils.h"
+#include <stdio.h>
+#include <cjson/cJSON.h>
+#include "rest_server.h"
+
+struct ConnectionInfo {
+    char *data;
+    size_t size;
+};
+
+static int handle_post_payload(const char *json) {
+    syslog(LOG_INFO, "Received POST payload");
+    return process_json_payload(json);
+}
+
+// Function to send response
+enum MHD_Result send_response(struct MHD_Connection *connection, const char *message) {
+        struct MHD_Response *response = MHD_create_response_from_buffer(strlen(message),
+                        (void *)message,
+                        MHD_RESPMEM_MUST_COPY);
+        enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+        MHD_destroy_response(response);
+        return ret;
+}
+
+enum MHD_Result handle_post_request(
+		void *cls,
+		struct MHD_Connection *connection,
+		const char *url,
+		const char *method,
+		const char *version,
+		const char *upload_data,
+		size_t *upload_data_size,
+		void **con_cls)
+{
+	log_debug("handle_request called for URL: %s ", url);
+	fflush(stdout);
+
+	if (strcmp(method, "POST") == 0 && strcmp(url, "/deviceconfigure") == 0){
+
+		struct ConnectionInfo *con_info = *con_cls;
+
+		if (*con_cls == NULL) {
+			con_info = calloc(1, sizeof(struct ConnectionInfo));
+			if (con_info == NULL) return MHD_NO;
+			*con_cls = con_info;
+			return MHD_YES;
+		}
+
+		if (*upload_data_size != 0) {
+			log_debug("upload_data_size: %zu bytes", *upload_data_size);
+			fflush(stdout);
+
+			con_info->data = realloc(con_info->data, con_info->size + *upload_data_size + 1);
+			memcpy(con_info->data + con_info->size, upload_data, *upload_data_size);
+			con_info->size += *upload_data_size;
+			con_info->data[con_info->size] = '\0';
+
+			*upload_data_size = 0; // Reset upload size to indicate data is processed
+			return MHD_YES;
+		}
+
+		// Only process the request after all data is received
+		log_debug("Full JSON Payload: %s", con_info->data);
+		fflush(stdout);
+
+		int result = handle_post_payload(con_info->data);
+
+		// Prepare response
+		char response_text[256];
+		if (result == 0) {
+			snprintf(response_text, sizeof(response_text),
+					"{\"status\": \"success\", \"message\": \" device Configuration updated successfully\"}");
+
+			cJSON *json_data = cJSON_Parse(con_info->data);
+			if (json_data) {
+				//save_taos_config(json_data);
+				//cJSON_Delete(json_data);
+			} else {
+				printf( "[ERROR] Invalid config JSON received.\n");
+			}
+
+		} else {
+			snprintf(response_text, sizeof(response_text),
+					"{\"status\": \"error\", \"message\": \"Device Configuration update failed\"}");
+		}
+		free(con_info->data);
+		free(con_info);
+		return send_response(connection, response_text);
+	}
+
+	return MHD_NO;
+}
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+make clean
+make
+make run


### PR DESCRIPTION
- Introduced REST server supporting POST, GET, and DELETE methods
- Added signal handling for graceful shutdown using SIGINT
- Integrated syslog-based logging with configurable log levels
- Implemented device configuration parsing and JSON handling
- Added sample configuration and datapoint payloads for testing
- Updated Makefile to support debug level selection at build time