### PR TITLE
Add OPC UA client thread with typed value storage and REST enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 # Variables
 CC = gcc
 CFLAGS = -I./include -DCURRENT_LOG_LEVEL=LOG_LEVEL_DEBUG
-LIBS = -lmicrohttpd -lcjson -lpthread
+LIBS = -lmicrohttpd -lcjson -lpthread -lopen62541
 
 # Directories
 SRC_DIR = src
 BIN_DIR = bin
 
 # Source and object files
-SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c
-OBJS = $(patsubst $(SRC_DIR)/%.c, $(BIN_DIR)/%.o, $(SRCS))
+SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c $(SRC_DIR)/opcua_client.c
+OBJS = $(SRCS:.c=.o)
+OBJS := $(patsubst src/%,bin/%,$(OBJS))
 
 # Target executable
 TARGET = $(BIN_DIR)/iot_connector

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -1,6 +1,10 @@
 #ifndef DEVICE_CONFIG_H
 #define DEVICE_CONFIG_H
+
 #define MAX_DATA_POINTS 50
+
+#include <stdbool.h>
+#include <open62541/client.h>
 
 typedef struct {
     int namespace;
@@ -32,8 +36,47 @@ typedef struct {
     MQTTConfig mqtt;
     DataPoint data_points[MAX_DATA_POINTS];
     int num_data_points;
+    bool active;
 } DeviceConfig;
 
 extern DeviceConfig g_device_config;
+
+typedef enum {
+    TYPE_BOOL,
+    TYPE_INT16,
+    TYPE_UINT16,
+    TYPE_INT32,
+    TYPE_UINT32,
+    TYPE_INT64,
+    TYPE_UINT64,
+    TYPE_FLOAT,
+    TYPE_DOUBLE,
+    TYPE_STRING,
+    TYPE_DATETIME,
+    TYPE_UNKNOWN
+} ValueType;
+
+typedef struct {
+    char alias[64];
+    ValueType type;
+    bool ready;
+
+    union {
+        UA_Boolean v_bool;
+        UA_Int16 v_int16;
+        UA_UInt16 v_uint16;
+        UA_Int32 v_int32;
+        UA_UInt32 v_uint32;
+        UA_Int64 v_int64;
+        UA_UInt64 v_uint64;
+        UA_Float v_float;
+        UA_Double v_double;
+        UA_String v_string;
+        UA_DateTime v_datetime;
+    } value;
+
+} OPCUAValue;
+
+extern OPCUAValue g_opcua_values[MAX_DATA_POINTS];
 
 #endif // DEVICE_CONFIG_H

--- a/include/opcua_client.h
+++ b/include/opcua_client.h
@@ -1,0 +1,10 @@
+#ifndef OPCUA_CLIENT_H
+#define OPCUA_CLIENT_H
+
+#include <pthread.h>
+
+// Thread function to monitor OPC UA data points
+void *opcua_client_thread(void *arg);
+
+#endif // OPCUA_CLIENT_H
+

--- a/metadata/cnc_device_002.json
+++ b/metadata/cnc_device_002.json
@@ -1,7 +1,7 @@
 {
 	"device_name":	"cnc_device_002",
 	"opcua":	{
-		"endpoint_url":	"opc.tcp://192.168.1.100:4840",
+		"endpoint_url":	"opc.tcp://fedora:53530/OPCUA/SimulationServer",
 		"username":	"opcuser",
 		"password":	"opcpass"
 	},
@@ -17,18 +17,18 @@
 	},
 	"data_points":	[{
 			"namespace":	3,
+			"identifier":	1007,
+			"datatype":	"Double",
+			"alias":	"Constant"
+		}, {
+			"namespace":	3,
 			"identifier":	1001,
-			"datatype":	"int32",
-			"alias":	"spindle_speed"
+			"datatype":	"",
+			"alias":	"Count"
 		}, {
 			"namespace":	3,
 			"identifier":	1002,
-			"datatype":	"float",
-			"alias":	"motor_temp"
-		}, {
-			"namespace":	3,
-			"identifier":	1003,
-			"datatype":	"boolean",
-			"alias":	"alarm_status"
+			"datatype":	"Double",
+			"alias":	"Random"
 		}]
 }

--- a/src/json_utils.c
+++ b/src/json_utils.c
@@ -153,6 +153,9 @@ int process_json_payload(const char *json) {
 
     log_device_config(&g_device_config);
     cJSON_Delete(root);
+
+    g_device_config.active = true;
+    log_debug("Device getting Active");
     return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,8 @@
 #include <dirent.h>
 #include <string.h>
 #include "json_utils.h"
+#include <pthread.h>
+#include "opcua_client.h"
 
 static volatile int running = 1;
 
@@ -87,10 +89,23 @@ int main() {
 	}
 	log_info("DELETE server running on port %d", DEL_PORT);
 
+	// OPC UA Worker Thread
+	pthread_t opcua_thread;
+	if (pthread_create(&opcua_thread, NULL, opcua_client_thread, NULL) != 0) {
+        log_error("Failed to create OPC UA thread");
+        return 1;
+	}
+
 	// Run until Ctrl+C
 	while (running) {
 		sleep(1);
 	}
+
+	// Notify thread to stop (if needed)
+	//g_device_config.active = false;
+
+	// Wait for thread to exit
+	//pthread_join(opcua_thread, NULL);
 
 	log_info("Shutting down servers...");
 	MHD_stop_daemon(daemon_post);

--- a/src/opcua_client.c
+++ b/src/opcua_client.c
@@ -1,0 +1,175 @@
+#include <pthread.h>
+#include "log_utils.h"
+#include "opcua_client.h"
+#include <unistd.h>
+#include <open62541/client_config_default.h>
+#include <open62541/client_highlevel.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include "device_config.h"
+
+OPCUAValue g_opcua_values[MAX_DATA_POINTS];
+
+#define MAX_RECONNECT_ATTEMPTS 5
+
+void log_opcua_values() {
+	for (int i = 0; i < MAX_DATA_POINTS; i++) {
+		OPCUAValue *val = &g_opcua_values[i];
+		if (!val->ready)
+			continue;  // Skip if data is not ready
+
+		switch (val->type) {
+			case TYPE_BOOL:
+				log_debug("Alias='%s' → Boolean=%s", val->alias, val->value.v_bool ? "true" : "false");
+				break;
+			case TYPE_INT16:
+				log_debug("Alias='%s' → Int16=%d", val->alias, val->value.v_int16);
+				break;
+			case TYPE_UINT16:
+				log_debug("Alias='%s' → UInt16=%u", val->alias, val->value.v_uint16);
+				break;
+			case TYPE_INT32:
+				log_debug("Alias='%s' → Int32=%d", val->alias, val->value.v_int32);
+				break;
+			case TYPE_UINT32:
+				log_debug("Alias='%s' → UInt32=%u", val->alias, val->value.v_uint32);
+				break;
+			case TYPE_INT64:
+				log_debug("Alias='%s' → Int64=%" PRId64, val->alias, val->value.v_int64);
+				break;
+			case TYPE_UINT64:
+				log_debug("Alias='%s' → UInt64=%" PRIu64, val->alias, val->value.v_uint64);
+				break;
+			case TYPE_FLOAT:
+				log_debug("Alias='%s' → Float=%.2f", val->alias, val->value.v_float);
+				break;
+			case TYPE_DOUBLE:
+				log_debug("Alias='%s' → Double=%.2f", val->alias, val->value.v_double);
+				break;
+			case TYPE_STRING:
+				log_debug("Alias='%s' → String='%.*s'", val->alias,
+						(int)val->value.v_string.length, (const char *)val->value.v_string.data);
+				break;
+			case TYPE_DATETIME: {
+						    UA_DateTimeStruct dts = UA_DateTime_toStruct(val->value.v_datetime);
+						    log_debug("Alias='%s' → DateTime=%04u-%02u-%02u %02u:%02u:%02u",
+								    val->alias, dts.year, dts.month, dts.day, dts.hour, dts.min, dts.sec);
+						    break;
+					    }
+			case TYPE_UNKNOWN:
+			default:
+					    log_warn("Alias='%s' → Unknown or unsupported type", val->alias);
+					    break;
+		}
+	}
+	log_debug("\n");
+}
+
+void *opcua_client_thread(void *arg) {
+	log_info("OPC UA thread started");
+
+	UA_Client *client = NULL;
+	UA_StatusCode status;
+	int reconnect_attempts = 0;
+
+	while (1) {
+		if (!g_device_config.active) {
+			log_debug("OPC UA inactive, waiting...");
+			sleep(1);
+			continue;
+		}
+
+		if (!client) {
+			client = UA_Client_new();
+			UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+			log_info("Attempting to connect to OPC UA server: %s", g_device_config.opcua.endpoint_url);
+			status = UA_Client_connect(client, g_device_config.opcua.endpoint_url);
+
+			if (status != UA_STATUSCODE_GOOD) {
+				log_error("Connection failed: %s", UA_StatusCode_name(status));
+				UA_Client_delete(client);
+				client = NULL;
+				/*
+				   reconnect_attempts++;
+				   if (reconnect_attempts > MAX_RECONNECT_ATTEMPTS) {
+				   log_error("Max reconnection attempts reached. Giving up.");
+				   break;
+				   }*/
+				sleep(2);
+				continue;
+			}
+
+			log_info("Connected to OPC UA server successfully");
+			//    reconnect_attempts = 0;
+		}
+
+		for (int i = 0; i < g_device_config.num_data_points; ++i) {
+			DataPoint *dp = &g_device_config.data_points[i];
+			OPCUAValue *val_out = &g_opcua_values[i];
+			strncpy(val_out->alias, dp->alias, sizeof(val_out->alias) - 1);
+			val_out->ready = false;
+
+			UA_Variant value;
+			UA_Variant_init(&value);
+
+			UA_NodeId nodeId = UA_NODEID_NUMERIC(dp->namespace, dp->identifier);
+			status = UA_Client_readValueAttribute(client, nodeId, &value);
+
+			if (status == UA_STATUSCODE_GOOD && value.type && value.data) {
+				if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_BOOLEAN])) {
+					val_out->type = TYPE_BOOL;
+					val_out->value.v_bool = *(UA_Boolean *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_INT16])) {
+					val_out->type = TYPE_INT16;
+					val_out->value.v_int16 = *(UA_Int16 *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_UINT16])) {
+					val_out->type = TYPE_UINT16;
+					val_out->value.v_uint16 = *(UA_UInt16 *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_INT32])) {
+					val_out->type = TYPE_INT32;
+					val_out->value.v_int32 = *(UA_Int32 *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_UINT32])) {
+					val_out->type = TYPE_UINT32;
+					val_out->value.v_uint32 = *(UA_UInt32 *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_INT64])) {
+					val_out->type = TYPE_INT64;
+					val_out->value.v_int64 = *(UA_Int64 *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_UINT64])) {
+					val_out->type = TYPE_UINT64;
+					val_out->value.v_uint64 = *(UA_UInt64 *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_FLOAT])) {
+					val_out->type = TYPE_FLOAT;
+					val_out->value.v_float = *(UA_Float *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_DOUBLE])) {
+					val_out->type = TYPE_DOUBLE;
+					val_out->value.v_double = *(UA_Double *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_STRING])) {
+					val_out->type = TYPE_STRING;
+					val_out->value.v_string = *(UA_String *)value.data;
+				} else if (UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_DATETIME])) {
+					val_out->type = TYPE_DATETIME;
+					val_out->value.v_datetime = *(UA_DateTime *)value.data;
+				} else {
+					val_out->type = TYPE_UNKNOWN;
+				}
+
+				val_out->ready = true;
+				log_opcua_values();//To print all stored OPC UA values (g_opcua_values[]) 
+
+			} else {
+				val_out->type = TYPE_UNKNOWN;
+				val_out->ready = false;
+			}
+			UA_Variant_clear(&value);
+		}
+
+		sleep(g_device_config.mqtt.publish_interval_ms / 1000); // avoid busy polling
+	}
+
+	if (client)
+		UA_Client_delete(client);
+
+	return NULL;
+}
+


### PR DESCRIPTION
- Implemented `opcua_client_thread` to monitor OPC UA variables based on `active` flag
- Stored OPC UA read values in `g_opcua_values[]` using native data types (Int, Float, String, DateTime, etc.)
- Added `log_opcua_values()` to print collected values with alias names and correct formatting
- Extended device configuration handling with value-ready flag for MQTT publishing
- Updated Makefile to include `opcua_client.c` and header
- Added new device config sample: `cnc_device_002.json`