### PR TITLE
opcua: add structured OPCUAValue logging and JSON payload generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC_DIR = src
 BIN_DIR = bin
 
 # Source and object files
-SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c $(SRC_DIR)/opcua_client.c
+SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c $(SRC_DIR)/opcua_client.c $(SRC_DIR)/mqtt.c
 OBJS = $(SRCS:.c=.o)
 OBJS := $(patsubst src/%,bin/%,$(OBJS))
 

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -77,6 +77,4 @@ typedef struct {
 
 } OPCUAValue;
 
-extern OPCUAValue g_opcua_values[MAX_DATA_POINTS];
-
 #endif // DEVICE_CONFIG_H

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1,0 +1,40 @@
+#ifndef _MQTT_H_
+#define _MQTT_H_
+
+/* QUEUE SETTINGS */
+#define QUEUE_CAPACITY 5 // Max queue size
+
+/* JSON DATA SIZE */
+#define MAX_JSON_SIZE 1000
+
+
+#define CLEAR                     0U
+#define SET                       1U
+#define INIT_VAL                  0U
+
+/* ERROR CODE */
+#define E_OK                    0
+#define ENOT_OK                 1
+#define MQTT_INTERVAL		2
+#include "device_config.h"
+
+extern volatile uint8_t DataDelay_cntr;
+
+#include "mqtt_queue.h"
+
+typedef struct {
+    char json_payload[MAX_JSON_SIZE];  // Holds the final JSON payload
+    bool json_ready;          // Flag to indicate if the payload is ready
+} mqtt_data_st;
+
+uint8_t data_collection(OPCUAValue *);
+uint8_t mqtt_init(void);
+bool mqtt_deinit(void);
+static bool mqtt_client_deinit(void);
+static bool mqtt_client_init();
+void write_payloads_to_file(Queue *queue);
+void write_payloads_to_csv(Queue *queue);
+bool readfile_publish_init(void);
+void publish_message(const char *message);
+
+#endif

--- a/include/mqtt_queue.h
+++ b/include/mqtt_queue.h
@@ -1,0 +1,28 @@
+#ifndef _MQTT_QUEUE_H_
+#define _MQTT_QUEUE_H_
+
+/* Define the structure for a queue element */
+typedef struct {
+    char json_data[MAX_JSON_SIZE];
+} QueueElement;
+
+/* Define the structure for the queue */
+typedef struct {
+    QueueElement elements[QUEUE_CAPACITY];
+    int front;
+    int rear;
+    int size;
+} Queue;
+
+/* declared variable to hold mqtt queue data */
+extern Queue queue;
+
+/* Function prototype */
+void MqttQueue_init(Queue *queue);
+static int isFull(Queue *queue);
+static int isEmpty(Queue *queue);
+int enqueue(Queue *queue, const char *json_data);
+int dequeue(Queue *queue, char *buffer);
+
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include "json_utils.h"
 #include <pthread.h>
 #include "opcua_client.h"
+#include <stdbool.h>
 
 static volatile int running = 1;
 
@@ -91,7 +92,8 @@ int main() {
 
 	// OPC UA Worker Thread
 	pthread_t opcua_thread;
-	if (pthread_create(&opcua_thread, NULL, opcua_client_thread, NULL) != 0) {
+	bool tid_sts = 1;
+	if (pthread_create(&opcua_thread, NULL, opcua_client_thread, &tid_sts) != 0) {
         log_error("Failed to create OPC UA thread");
         return 1;
 	}
@@ -102,10 +104,9 @@ int main() {
 	}
 
 	// Notify thread to stop (if needed)
-	//g_device_config.active = false;
-
+	tid_sts = 0;
 	// Wait for thread to exit
-	//pthread_join(opcua_thread, NULL);
+	pthread_join(opcua_thread, NULL);
 
 	log_info("Shutting down servers...");
 	MHD_stop_daemon(daemon_post);

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -1,0 +1,137 @@
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "log_utils.h"
+#include"mqtt.h"
+
+mqtt_data_st mqtt_data = { .json_payload = "", .json_ready = false };
+
+
+// Function to build the JSON payload
+void build_opcua_json_payload(OPCUAValue *g_opcua_values, char *json_payload) {
+    char entry[512];
+    strcpy(json_payload, "[");  // Start of JSON array
+
+    for (int i = 0; i < g_device_config.num_data_points; ++i) {
+        OPCUAValue *val = &g_opcua_values[i];
+        if (!val->ready)
+            continue;
+
+        // Get current UTC timestamp
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        struct tm *tm_info = gmtime(&ts.tv_sec);
+        char timestamp[64];
+        snprintf(timestamp, sizeof(timestamp), "%04d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
+                 tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday,
+                 tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec, ts.tv_nsec / 1000000);
+
+        // Determine type string and value string
+        const char *type_str = "unknown";
+        char value_str[256] = {0};
+
+        switch (val->type) {
+            case TYPE_BOOL:
+                type_str = "bool";
+                snprintf(value_str, sizeof(value_str), "%s", val->value.v_bool ? "true" : "false");
+                break;
+            case TYPE_INT16:
+                type_str = "int16";
+                snprintf(value_str, sizeof(value_str), "%d", val->value.v_int16);
+                break;
+            case TYPE_UINT16:
+                type_str = "uint16";
+                snprintf(value_str, sizeof(value_str), "%u", val->value.v_uint16);
+                break;
+            case TYPE_INT32:
+                type_str = "int32";
+                snprintf(value_str, sizeof(value_str), "%d", val->value.v_int32);
+                break;
+            case TYPE_UINT32:
+                type_str = "uint32";
+                snprintf(value_str, sizeof(value_str), "%u", val->value.v_uint32);
+                break;
+            case TYPE_INT64:
+                type_str = "int64";
+                snprintf(value_str, sizeof(value_str), "%lld", (long long)val->value.v_int64);
+                break;
+            case TYPE_UINT64:
+                type_str = "uint64";
+                snprintf(value_str, sizeof(value_str), "%llu", (unsigned long long)val->value.v_uint64);
+                break;
+            case TYPE_FLOAT:
+                type_str = "float";
+                snprintf(value_str, sizeof(value_str), "%.3f", val->value.v_float);
+                break;
+            case TYPE_DOUBLE:
+                type_str = "double";
+                snprintf(value_str, sizeof(value_str), "%.6f", val->value.v_double);
+                break;
+            case TYPE_STRING:
+                type_str = "string";
+                snprintf(value_str, sizeof(value_str), "\"%s\"", (const char *)val->value.v_string.data);
+                break;
+            case TYPE_DATETIME:
+                type_str = "datetime";
+                snprintf(value_str, sizeof(value_str), "\"<datetime>\"");  // Format UA_DateTime if needed
+                break;
+            default:
+                snprintf(value_str, sizeof(value_str), "\"unsupported\"");
+                break;
+        }
+
+        // Construct JSON entry
+        snprintf(entry, sizeof(entry),
+                 "{\"tag\":\"%s\",\"type\":\"%s\",\"value\":%s,\"timestamp\":\"%s\",\"quality\":\"good\"}",
+                 val->alias, type_str, value_str, timestamp);
+
+        strcat(json_payload, entry);
+        if (i < g_device_config.num_data_points - 1)
+            strcat(json_payload, ",");
+    }
+
+    strcat(json_payload, "]");
+}
+
+// Function to handle data enqueueing with delay check
+/*static uint8_t enqueue_data(char *json_payload) {
+
+        // Enqueue the data every 5 sec
+        if (DataDelay_cntr == MQTT_INTERVAL) {
+                if (enqueue(&queue, json_payload) == 1) {
+                        printf("ERR: Enqueue failed...\n");
+                        DataDelay_cntr = CLEAR;  // Clear the counter after enqueueing
+                        //return 1;
+                }
+        DataDelay_cntr = CLEAR;  // Clear the counter after enqueueing
+        }
+
+        return E_OK;
+}
+*/
+/**
+ * @brief Collects machine data, formats it as a JSON payload, and enqueues it for publishing.
+ * @param machn_data Pointer to a `machine_data_end` structure containing the machine data to be collected.
+ * @return void
+ */
+
+// Updated data_collection function
+uint8_t data_collection(OPCUAValue *g_opcua_values) {
+
+        // Build the JSON payload
+        build_opcua_json_payload(g_opcua_values, mqtt_data.json_payload);
+
+        // Mark the payload as ready
+        mqtt_data.json_ready = true;
+
+	printf("json payload %s\n",mqtt_data.json_payload);
+        // Enqueue data if delay condition is met
+        /*if(enqueue_data(mqtt_data.json_payload)){
+                return ENOT_OK;
+        }
+*/
+        return E_OK;
+}
+


### PR DESCRIPTION
This patch introduces structured handling and logging of OPC UA read values. A new `OPCUAValue` structure includes alias names, data types, readiness flags, and union-based storage for various data types.

Highlights:
- Added `OPCUAValue` struct with alias name, type, and ready flag.
- Implemented `log_opcua_values()` for logging all ready values with alias and type.
- Added `build_opcua_json_payload()` function to construct a JSON array from ready OPC UA values.
- Each JSON entry includes tag, type, value, timestamp (ISO 8601), and quality.

This enables better telemetry representation for MQTT/REST consumption.