### PR TITLE
connector: add OPC UA read support with typed value MQTT publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Variables
 CC = gcc
 CFLAGS = -I./include -DCURRENT_LOG_LEVEL=LOG_LEVEL_DEBUG
-LIBS = -lmicrohttpd -lcjson -lpthread -lopen62541
+LIBS = -lmicrohttpd -lcjson -lpthread -lopen62541 -lpaho-mqtt3c -lrt
 
 # Directories
 SRC_DIR = src
 BIN_DIR = bin
 
 # Source and object files
-SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c $(SRC_DIR)/opcua_client.c $(SRC_DIR)/mqtt.c
+SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/rest_server.c $(SRC_DIR)/json_utils.c $(SRC_DIR)/opcua_client.c $(SRC_DIR)/mqtt.c $(SRC_DIR)/mqtt_queue.c
 OBJS = $(SRCS:.c=.o)
 OBJS := $(patsubst src/%,bin/%,$(OBJS))
 

--- a/include/config.sh
+++ b/include/config.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# MQTT Timer Configuration
+export MQTT_TIMER_INITIAL_START=2
+export MQTT_INTERVAL=2  # 5 sec publish interval
+
+# Reconnect Settings
+export RECONNECT_CNT=4  # 20 attempts to reconnect
+
+# FOCAS Timer Configuration
+export OPCUA_TIMER_INITIAL_START=1
+export OPCUA_INTERVAL=1  # 1 sec polling interval
+
+export OPCUA_FILE_PATH="buffer_data/opcua_buffer.json"
+
+# MQTT Configuration
+export MQTT_BROKER="tcp://localhost:1883"
+export MQTT_CLIENTID="LocalClient1234"
+export MQTT_TOPIC="test/topic"
+export MQTT_QOS=1
+export MQTT_TIMEOUT=10000  # 10-second timeout
+
+
+
+#!/bin/bash
+
+# Function to check if an environment variable is set
+check_env_var() {
+    if [ -z "${!1}" ]; then
+        echo "❌ ERROR: $1 is not set!"
+        MISSING_VARS=1
+    else
+        echo "✅ $1 = ${!1}"
+    fi
+}
+
+echo "🔍 Checking required environment variables..."
+
+# List of required environment variables
+MISSING_VARS=0
+check_env_var "MQTT_TIMER_INITIAL_START"
+check_env_var "MQTT_INTERVAL"
+check_env_var "RECONNECT_CNT"
+check_env_var "OPCUA_FILE_PATH"
+check_env_var "MQTT_BROKER"
+check_env_var "MQTT_CLIENTID"
+check_env_var "MQTT_TOPIC"
+check_env_var "MQTT_QOS"
+check_env_var "MQTT_TIMEOUT"
+
+# If any variable is missing, exit the script
+if [ "$MISSING_VARS" -ne 0 ]; then
+    echo "❌ Exiting due to missing environment variables!"
+    exit 1
+fi
+
+echo "✅ All required environment variables are set!"
+echo "🚀 Starting the application..."
+
+

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1,5 +1,9 @@
 #ifndef _MQTT_H_
 #define _MQTT_H_
+#include "device_config.h"
+#include <MQTTClient.h>
+#include <stdlib.h>
+#include <signal.h>
 
 /* QUEUE SETTINGS */
 #define QUEUE_CAPACITY 5 // Max queue size
@@ -15,8 +19,32 @@
 /* ERROR CODE */
 #define E_OK                    0
 #define ENOT_OK                 1
-#define MQTT_INTERVAL		2
-#include "device_config.h"
+
+/* MQTT TIMER CONFIGURATION */
+#define MQTT_TIMER_INITIAL_START (getenv("MQTT_TIMER_INITIAL_START") ? atoi(getenv("MQTT_TIMER_INITIAL_START")) : 2)
+#define MQTT_INTERVAL (getenv("MQTT_INTERVAL") ? atoi(getenv("MQTT_INTERVAL")) : 2) // Publish interval
+
+/* RECONNECT SETTINGS */
+#define RECONNECT_CNT (getenv("RECONNECT_CNT") ? atoi(getenv("RECONNECT_CNT")) : 4) // Max reconnection attempts
+
+/* QUEUE SETTINGS */
+//#define QUEUE_CAPACITY (getenv("QUEUE_CAPACITY") ? atoi(getenv("QUEUE_CAPACITY")) : 5) // Max queue size
+
+/* FOCAS TIMER CONFIGURATION */
+#define OPCUA_TIMER_INITIAL_START (getenv("FOCAS_TIMER_INITIAL_START") ? atoi(getenv("FOCAS_TIMER_INITIAL_START")) : 1)
+#define OPCUA_INTERVAL (getenv("FOCAS_INTERVAL") ? atoi(getenv("FOCAS_INTERVAL")) : 1) // Polling interval
+
+#define FILE_PATH (getenv("FOCAS_FILE_PATH") ? getenv("FOCAS_FILE_PATH") : "buffer_data/focas_buffer.json")
+
+/* MQTT CONFIGURATION */
+#define ADDRESS (getenv("MQTT_BROKER") ? getenv("MQTT_BROKER") : "tcp://localhost:1883")
+#define CLIENTID (getenv("MQTT_CLIENTID") ? getenv("MQTT_CLIENTID") : "LocalClient1234")
+#define TOPIC (getenv("MQTT_TOPIC") ? getenv("MQTT_TOPIC") : "test/topic")
+#define QOS (getenv("MQTT_QOS") ? atoi(getenv("MQTT_QOS")) : 1) // At least once delivery guarantee
+#define TIMEOUT (getenv("MQTT_TIMEOUT") ? atol(getenv("MQTT_TIMEOUT")) : 10000L) // 10-second timeout
+
+/* JSON DATA SIZE */
+//#define MAX_JSON_SIZE (getenv("MAX_JSON_SIZE") ? atoi(getenv("MAX_JSON_SIZE")) : 1000)
 
 extern volatile uint8_t DataDelay_cntr;
 

--- a/src/file_write.c
+++ b/src/file_write.c
@@ -1,0 +1,143 @@
+#include"mqtt.h"
+#include <stdio.h>
+
+static pthread_t file_tid;
+extern volatile char file_flag ;
+
+void write_payloads_to_file(Queue *queue) {
+    FILE *file = fopen(FILE_PATH, "r+"); // Open file in read/write mode
+    if (file == NULL) {
+        perror("Failed to open JSON file");
+        return;
+    }   
+
+    // Check if the file is empty or already contains a JSON array
+    fseek(file, 0, SEEK_END);
+    long file_size = ftell(file);
+    if (file_size == 0) {
+        // If the file is empty, write the opening square bracket
+        fseek(file, 0, SEEK_SET);
+        fprintf(file, "[\n");
+    } else {
+        // If the file already contains data, go back to the last character (the closing bracket)
+        fseek(file, -2, SEEK_END); // Move back two characters from EOF
+        fprintf(file, ",\n");
+    }   
+
+    // Write the new payloads
+    for (int i = 0; i < QUEUE_CAPACITY; i++) {
+        fprintf(file, "  %s%s\n", queue->elements[i].json_data, (i < QUEUE_CAPACITY - 1) ? "," : "");
+    }   
+
+    // Close the JSON array if this is the last write
+    fprintf(file, "]\n");
+    fclose(file);
+    printf("%d JSON payloads written to file.\n", QUEUE_CAPACITY);
+}
+// Function to read JSON payloads from the file
+json_object* read_payloads_from_file(const char *file_path) {
+    FILE *file = fopen(file_path, "r");
+    if (file == NULL) {
+        perror("Error opening file");
+        return NULL;
+    }
+
+    fseek(file, 0, SEEK_END);
+    long file_size = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    char *buffer = (char *)malloc(file_size + 1);
+    if (buffer == NULL) {
+        perror("Memory allocation error");
+        fclose(file);
+        return NULL;
+    }
+/*
+        // Allocate a fixed-size buffer to hold the file contents
+    char buffer[MAX_FILE_SIZE];
+    
+    // Read the file into the buffer
+    size_t bytes_read = fread(buffer, 1, MAX_FILE_SIZE - 1, file);
+    if (bytes_read == 0) {
+        fclose(file);
+        return NULL;
+    }
+        
+*/
+    fread(buffer, 1, file_size, file);
+    buffer[file_size] = '\0';
+    fclose(file);
+
+    json_object *data = json_tokener_parse(buffer);
+    free(buffer);
+
+    if (data == NULL) {
+        fprintf(stderr, "Error parsing JSON or file empty\n");
+    }
+
+    return data;
+}
+int delete_file_content(const char *file_path) {
+    // Open the file in write mode ("w") to truncate it
+    FILE *file = fopen(file_path, "w");
+    if (file == NULL) {
+        perror("Error opening file");
+        return -1;  // Return an error if the file cannot be opened
+    }
+
+    // No need to write anything, just truncating the file
+    fclose(file);
+
+    printf("File content deleted successfully.\n");
+    return 0;  // Success
+}
+
+// Function to publish payloads to the MQTT broker
+void publish_payloads_to_mqtt(json_object *payloads) {
+        if (payloads == NULL) {
+                printf("No payloads to publish.\n");
+                return;
+        }
+
+        MQTTClient_message pubmsg = MQTTClient_message_initializer;
+        char ret;
+
+        // Loop through each JSON object in the array
+        size_t num_payloads = json_object_array_length(payloads);
+        for (size_t i = 0; i < num_payloads; i++) {
+                printf("buffer ");
+                json_object *payload = json_object_array_get_idx(payloads, i);
+                const char *json_payload = json_object_to_json_string(payload);
+                usleep(1000);
+                publish_message(json_payload);
+        }
+                printf("All payloads published successfully\n");
+}
+
+void *file_handler(void *arg){
+        while(1){
+                if(file_flag){
+                        printf("to readddddd file content\n");
+                        // Read payloads from the file
+                        json_object *payloads = read_payloads_from_file(FILE_PATH);
+
+                        // Publish the payloads to MQTT
+                        if (payloads) {
+                                publish_payloads_to_mqtt(payloads);
+                                json_object_put(payloads); // Free JSON object
+                                delete_file_content(FILE_PATH);
+                        }
+                        file_flag = CLEAR;
+
+                }
+        }
+}
+
+bool readfile_publish_init(){
+
+        if (pthread_create(&file_tid, NULL, file_handler,NULL) != 0) {
+                perror("Failed to create focas_tid");
+                return ENOT_OK;
+        }
+        return E_OK;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include "opcua_client.h"
 #include <stdbool.h>
+#include "mqtt.h"
 
 static volatile int running = 1;
 
@@ -51,6 +52,93 @@ void load_device_config() {
     }
 
     closedir(dir);
+}
+
+static timer_t opcua_timerid;                           // Timer ID
+static pthread_t opcua_tid;                             //thread ID
+
+static volatile uint8_t timer_flag = INIT_VAL;           // Flag to be monitored
+static volatile uint8_t timer_count = INIT_VAL;         // Timer count variable
+volatile uint8_t DataDelay_cntr = INIT_VAL;             // Timer count variable
+
+
+// Timer handler function
+static void opcua_timer_handler(union sigval sv) {
+        timer_count++;                                  // Increment the timer count every 1 second
+        DataDelay_cntr++;                               // free running counter for data delay  
+        // printf("Timer callback: Timer count = %d\n", timer_count);
+
+        // If the timer count completes 1 second, set the timer_flag
+        if (timer_count >= 1) {
+                if(!timer_flag)                         //if timer is 0 then only flag change to 1 poll start
+                        timer_flag = SET;               // Set the timer_flag
+
+                timer_count = CLEAR;                    // Reset the timer count for the next cycle
+        }
+}
+
+// Initialization function
+static bool opcua_timer_init() {
+        struct sigevent sev;
+        struct itimerspec its;
+
+        // Configure the timer event to call the timer_handler function
+        sev.sigev_notify = SIGEV_THREAD;                // Notify via a thread
+        sev.sigev_value.sival_ptr = &opcua_timerid;     // Pass timer ID to the handler
+        sev.sigev_notify_function = opcua_timer_handler;// Timer handler function
+        sev.sigev_notify_attributes = NULL;             // Default thread attributes
+
+        // Create the timer
+        if (timer_create(CLOCK_REALTIME, &sev, &opcua_timerid) == -1) {
+                perror("Failed to create timer");
+                return ENOT_OK;
+        }
+
+        // Configure the timer: 1-second interval
+        its.it_value.tv_sec = OPCUA_TIMER_INITIAL_START;// Initial expiration in seconds
+        its.it_value.tv_nsec = 0;                       // Initial expiration in nanoseconds
+        its.it_interval.tv_sec = OPCUA_INTERVAL;        // Periodic interval in seconds
+        its.it_interval.tv_nsec = 0;                    // Periodic interval in nanoseconds
+
+        // Start the timer
+        if (timer_settime(opcua_timerid, 0, &its, NULL) == -1) {
+                perror("Failed to start timer");
+                return ENOT_OK;
+        }
+
+        printf("Timer initialized and started.\n");
+        return E_OK;
+}
+
+static uint8_t opcua_init(){
+        int8_t ret = CLEAR;
+        ret = opcua_timer_init(&opcua_timerid); // Initialize the timer
+        if(ret){
+                return ENOT_OK;
+        }
+        printf("opcua timer initializion successfully\n");
+
+        return E_OK;
+}
+
+// Timer deinitialization function
+static void opcua_timer_deinit() {
+    // Check if timer exists and delete it
+    if (opcua_timerid) {
+        if (timer_delete(opcua_timerid) == -1) {
+            perror("Failed to delete opcua timer");
+        } else {
+            printf("Focas timer deleted successfully.\n");
+        }
+    } else {
+        printf("No valid opcua timer to delete.\n");
+    }
+}
+
+// Full deinitialization function
+static void opcua_deinit() {
+        opcua_timer_deinit();     // Deinitialize the timer
+        printf("Focas deinitialized successfully.\n");
 }
 
 int main() {
@@ -98,16 +186,31 @@ int main() {
         return 1;
 	}
 
+	char ret = 0;
+        ret = opcua_init(); // Create opcua_tid
+        if(ret){
+                goto D_INIT;
+        }
+
+	printf("opcua initializion successfully\n");
+	ret = mqtt_init();// Initialize mqtt
+        if(ret){
+                goto D_INIT;
+        }
+        log_debug("mqtt initialization is successfully\n");
+
 	// Run until Ctrl+C
 	while (running) {
 		sleep(1);
 	}
 
+D_INIT:
 	// Notify thread to stop (if needed)
 	tid_sts = 0;
 	// Wait for thread to exit
 	pthread_join(opcua_thread, NULL);
-
+	mqtt_deinit();
+	opcua_deinit();
 	log_info("Shutting down servers...");
 	MHD_stop_daemon(daemon_post);
 	MHD_stop_daemon(daemon_get);

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -4,10 +4,265 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "log_utils.h"
-#include"mqtt.h"
+#include "mqtt.h"
+#include "mqtt_queue.h"
 
 mqtt_data_st mqtt_data = { .json_payload = "", .json_ready = false };
 
+//timer
+static struct sigevent sev;
+static struct itimerspec ts; 
+static timer_t mqtt_timerid;
+static volatile uint8_t mqtt_exp = INIT_VAL; // to count reconnection exp count
+static pthread_mutex_t data_mutex; // Mutex for thread-safe access to the data
+static pthread_t mqtt_tid;
+static volatile char mqtt_flag = INIT_VAL; //based timer handler to set 1
+volatile char file_flag ;
+// MQTT client handle
+static MQTTClient client;
+extern mqtt_data_st mqtt_data;
+
+/**
+ * @brief Publishes a message to the MQTT broker on a predefined topic.
+ * @param message The message string to be published (null-terminated).
+ * @return void
+ */
+void publish_message(const char *message) {
+        MQTTClient_message pubmsg = MQTTClient_message_initializer;
+        MQTTClient_deliveryToken token;
+
+        pubmsg.payload = (void *)message;
+        pubmsg.payloadlen = (int)strlen(message);
+        pubmsg.qos = QOS;
+        pubmsg.retained = 0;
+
+        int rc = MQTTClient_publishMessage(client, TOPIC, &pubmsg, &token);
+        if (rc != MQTTCLIENT_SUCCESS) {
+                fprintf(stderr, "Failed to publish message: %s (Error: %d)\n", message, rc);
+        } else {
+                printf("Message published: %s\n", message);
+                MQTTClient_waitForCompletion(client, token, TIMEOUT);
+        }   
+}
+
+/**
+ * @brief Attempts to reconnect to the MQTT broker if the connection is lost.
+ * @return int Returns `MQTTCLIENT_SUCCESS` on success or an error code on failure.
+ */
+static int reconnect_mqtt() {
+        char ret = CLEAR;
+
+        if(mqtt_exp == RECONNECT_CNT){
+                ret = mqtt_client_deinit();
+                if(ret){
+                        return ENOT_OK;
+                }   
+
+                ret = mqtt_client_init();
+                if(ret){
+                        mqtt_exp = CLEAR;
+                        return ENOT_OK;
+                }
+                goto L1;
+        }
+
+        MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
+        conn_opts.keepAliveInterval = 20;
+        conn_opts.cleansession = 1;
+
+        ret = MQTTClient_connect(client, &conn_opts);
+        if (ret != MQTTCLIENT_SUCCESS) {
+                fprintf(stderr, "Failed to reconnect to broker. Error code: %d\n", ret);
+                mqtt_exp++;
+                return ENOT_OK;
+        }
+
+L1:
+        file_flag = SET;
+        mqtt_exp = CLEAR;
+        printf("Reconnected to MQTT broker at %s\n", ADDRESS);
+        return MQTTCLIENT_SUCCESS;
+}
+
+/**
+ * @brief Timer handler to check connection status, dequeue messages, and publish to the MQTT broker.
+ */
+static void mqtt_timer_handler(union sigval arg) {
+        mqtt_flag = SET;
+}
+
+/**
+ * @brief Initializes the MQTT client, connects to the broker, and sets up a recurring timer for message handling.
+ */
+static bool mqtt_mutex_init() {
+        // Initialize the mutex
+        if (pthread_mutex_init(&data_mutex, NULL) != 0) {
+                fprintf(stderr, "Error initializing mutex\n");
+                return ENOT_OK;
+        }
+        return E_OK;
+}
+
+static bool mqtt_client_init() {
+        char ret = CLEAR;
+
+        // Initialize MQTT client
+        MQTTClient_create(&client, ADDRESS, CLIENTID, MQTTCLIENT_PERSISTENCE_NONE, NULL);
+
+        MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
+        conn_opts.keepAliveInterval = 20;
+        conn_opts.cleansession = 1;
+
+        // Connect to the MQTT broker
+        if ((ret = MQTTClient_connect(client, &conn_opts)) != MQTTCLIENT_SUCCESS) {
+                fprintf(stderr, "Failed to connect to broker. Error code: %d\n", ret);
+                return ENOT_OK;
+        }
+        return E_OK;
+}
+static bool mqtt_timer_init() {
+        // Set up a timer to call the mqtt_timer_handler every 5 seconds
+        sev.sigev_notify = SIGEV_THREAD;
+        sev.sigev_notify_function = mqtt_timer_handler;
+        sev.sigev_notify_attributes = NULL;
+        sev.sigev_value.sival_ptr = &mqtt_timerid;
+
+        if (timer_create(CLOCK_REALTIME, &sev, &mqtt_timerid) == -1) {
+                perror("timer_create failed");
+                return ENOT_OK;
+        }
+
+        ts.it_value.tv_sec = MQTT_TIMER_INITIAL_START;  // Initial timer set to 5 seconds before the first interrupt
+        ts.it_value.tv_nsec = 0;
+        ts.it_interval.tv_sec = MQTT_INTERVAL;  // Repeat every 5 seconds
+        ts.it_interval.tv_nsec = 0;
+
+        if (timer_settime(mqtt_timerid, 0, &ts, NULL) == -1) {
+                perror("timer_settime failed");
+                return ENOT_OK;
+        }
+        printf("MQTT Timer init done\n");
+        return E_OK;
+}
+
+/**
+ * @brief mqtt thread to check connection status, dequeue messages, and publish to the MQTT broker every 5sec.
+ */
+static void *mqtt_thread(void *arg) {
+        while(1){
+                if(mqtt_flag){
+                        pthread_mutex_lock(&data_mutex);                                // Lock the mutex before accessing shared data
+                        char json_payload[MAX_JSON_SIZE];
+
+                        if (mqtt_data.json_ready) {
+                                if (MQTTClient_isConnected(client)) {                   // Check if the client is connected to the broker
+                                        if (dequeue(&queue, json_payload)) {      // If connected, publish the message
+                                                printf("MQ_ERR: Failed to dequeue message\n");
+                                        }
+                                        publish_message(json_payload);
+                                        mqtt_data.json_ready = false;                   // Reset the flag after sending
+                                } else {                                                // Attempt to reconnect if the client is not connected
+                                        if (reconnect_mqtt() == MQTTCLIENT_SUCCESS) {   // If reconnection is successful, publish the message
+                                                if (dequeue(&queue, json_payload)) {
+                                                        printf("MQ_ERR: Failed to dequeue message after reconnect \n");
+                                                }
+                                                publish_message(json_payload);
+                                                mqtt_data.json_ready = false;           // Reset the flag after sending
+                                        } else {
+                                                printf("Unable to reconnect to MQTT broker. Retrying...\n");
+                                        }
+                                }
+                        } else {
+                                printf("JSON payload not ready. Retrying...\n");
+                        }
+
+                        mqtt_flag = CLEAR;
+                        pthread_mutex_unlock(&data_mutex); // Unlock the mutex
+                }
+        }
+}
+static bool mqtt_thread_init(){
+        if (pthread_create(&mqtt_tid, NULL, mqtt_thread,NULL) != 0) {
+                log_error("Failed to create MQTT thread");
+                return ENOT_OK;
+        }
+        printf("MQTT Thread init done\n");
+        return E_OK;
+}
+
+uint8_t mqtt_init() {
+        char ret = 0 ;
+        // Initialize mqtt queue
+        MqttQueue_init(&queue);
+        // Split initialization tasks
+        ret = mqtt_mutex_init();
+        if(ret){
+                return ENOT_OK;
+        }
+
+        ret = mqtt_client_init();
+        if(ret){
+        //      return ENOT_OK;
+        }
+
+        ret = mqtt_timer_init();
+        if(ret){
+                return ENOT_OK;
+        }
+
+        ret = mqtt_thread_init();
+        if(ret){
+                return ENOT_OK;
+        }
+        return E_OK;
+}
+// Timer deinitialization
+static void mqtt_timer_deinit() {
+        if (timer_delete(mqtt_timerid) == -1) {
+                perror("Failed to delete timer");
+        } else {
+                printf("Timer deleted successfully.\n");
+        }
+}
+
+// Deinitialize MQTT client
+static bool  mqtt_client_deinit() {
+        char ret;
+
+        // Disconnect from the MQTT broker
+        if ((ret = MQTTClient_disconnect(client, 10000)) != MQTTCLIENT_SUCCESS) {
+                fprintf(stderr, "Failed to disconnect from broker. Error code: %d\n", ret);
+                return ENOT_OK;
+        } else {
+                printf("Disconnected from broker.\n");
+        }
+
+        // Destroy the MQTT client
+        MQTTClient_destroy(&client);
+
+        printf("MQTT client destroyed.\n");
+        return E_OK;
+}
+
+
+// Deinitialize the mutex
+static void mqtt_mutex_deinit() {
+        if (pthread_mutex_destroy(&data_mutex) != 0) {
+                fprintf(stderr, "Error destroying mutex\n");
+                // Handle error if needed
+        } else {
+                printf("Mutex destroyed successfully.\n");
+        }
+}
+bool mqtt_deinit(){
+        // Deinitialize the mutex before exiting
+        mqtt_mutex_deinit();
+        // Deinitialize MQTT client before exiting
+        bool ret = mqtt_client_deinit();
+        // Deinitialize the MQTT timer before exiting
+        mqtt_timer_deinit();
+
+}
 
 // Function to build the JSON payload
 void build_opcua_json_payload(OPCUAValue *g_opcua_values, char *json_payload) {
@@ -96,7 +351,7 @@ void build_opcua_json_payload(OPCUAValue *g_opcua_values, char *json_payload) {
 }
 
 // Function to handle data enqueueing with delay check
-/*static uint8_t enqueue_data(char *json_payload) {
+static uint8_t enqueue_data(char *json_payload) {
 
         // Enqueue the data every 5 sec
         if (DataDelay_cntr == MQTT_INTERVAL) {
@@ -110,7 +365,6 @@ void build_opcua_json_payload(OPCUAValue *g_opcua_values, char *json_payload) {
 
         return E_OK;
 }
-*/
 /**
  * @brief Collects machine data, formats it as a JSON payload, and enqueues it for publishing.
  * @param machn_data Pointer to a `machine_data_end` structure containing the machine data to be collected.
@@ -127,11 +381,10 @@ uint8_t data_collection(OPCUAValue *g_opcua_values) {
         mqtt_data.json_ready = true;
 
 	printf("json payload %s\n",mqtt_data.json_payload);
-        // Enqueue data if delay condition is met
-        /*if(enqueue_data(mqtt_data.json_payload)){
+         //Enqueue data if delay condition is met
+        if(enqueue_data(mqtt_data.json_payload)){
                 return ENOT_OK;
         }
-*/
         return E_OK;
 }
 

--- a/src/mqtt_queue.c
+++ b/src/mqtt_queue.c
@@ -1,0 +1,76 @@
+#include"mqtt.h"
+#include"log_utils.h"
+
+/* define variable to handle mqtt queue data */
+Queue queue ={0};
+
+/**
+ * @brief: Initializes the mqtt queue to its default empty state.
+ *
+ * @param: Queue *queue Pointer to the mqtt queue structure to initialize.
+ */
+void MqttQueue_init(Queue *queue) {
+        queue->front = CLEAR;
+        queue->rear = -1; 
+        queue->size = CLEAR;
+}
+/**
+ * @brief: Checks if the mqtt queue is full.
+ *
+ * @param: Queue *queue Pointer to the queue structure to check.
+ * @return: 1 if the queue is full, 0 otherwise.
+ */
+static int isFull(Queue *queue) {
+        return queue->size == QUEUE_CAPACITY;
+}
+/**
+ * @brief: Checks if the mqtt queue is empty.
+ *
+ * @param: queue Pointer to the mqtt queue structure to check.
+ * @return: 1 if the queue is empty, 0 otherwise.
+ */
+static int isEmpty(Queue *queue) {
+        return queue->size == 0;
+}
+/**
+ * @brief: Adds a new JSON record to the mqtt queue.
+ *
+ * @param: Queue *queue Pointer to the mqtt queue structure.
+ const char *json_data JSON string to enqueue.
+ * @return: 0 on success, -1 if the queue is full.
+ */
+int enqueue(Queue *queue, const char *json_data) {
+        if (isFull(queue)) {
+                //write_payloads_to_file(queue);
+                MqttQueue_init(queue);//reset 
+                log_debug("Queue is full...to write in the file\n");
+                //return -1;
+        }   
+        log_debug("current queue size%d\n ",queue->size);
+        queue->rear = (queue->rear + 1) % QUEUE_CAPACITY;
+        strncpy(queue->elements[queue->rear].json_data, json_data, MAX_JSON_SIZE - 1); 
+        log_debug("enqeue data %s\n",queue->elements[queue->rear].json_data);
+        queue->elements[queue->rear].json_data[MAX_JSON_SIZE - 1] = '\0';
+        queue->size++;
+        return E_OK;
+}
+/**
+ * @brief: Removes the oldest JSON record from the mqtt queue.
+ *
+ * @param: Queue *queue Pointer to the mqtt queue structure.
+ char *buffer Buffer to store the dequeued JSON string.
+ * @return: 0 on success, -1 if the mqtt queue is empty.
+ */
+int dequeue(Queue *queue, char *buffer) {
+        if (isEmpty(queue)) {
+                log_error("MQ_ERR: Queue is empty...\n");
+                return ENOT_OK;
+        }
+        log_debug("dequeue queue=%s\n",queue->elements[queue->front].json_data);
+        strncpy(buffer, queue->elements[queue->front].json_data, MAX_JSON_SIZE);
+        buffer[MAX_JSON_SIZE - 1] = '\0';
+        queue->front = (queue->front + 1) % QUEUE_CAPACITY;
+        queue->size--;
+        return E_OK;
+}
+ 

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,20 @@
+#!/bin/bash
+#set environment variable set
+source ./include/config.sh
+
+# Step 1: Clean the build
+echo "Cleaning the project..."
+rm -rf bin buffer_data
+mkdir -p bin buffer_data && touch buffer_data/focas_buffer.json
 make clean
+
+# Step 2: Build the project
+echo "Building the project..."
 make
+
+# Step 6: Verify dependencies
+echo "Verifying dependencies..."
+ldd bin/device_focas_c
+
 make run
+


### PR DESCRIPTION
This update implements end-to-end OPC UA variable handling, including reading, storing, logging, and publishing to MQTT with accurate data types.

Key changes:
- Added OPCUAValue struct with alias, data type, and ready flag
- Implemented opcua_client_thread() to read data based on device config
- Stored values in global g_opcua_values[] using native OPC UA types
- Added log_opcua_values() for structured logging of all ready tags
- Created build_opcua_json_payload() to format typed JSON for MQTT
- Enabled automatic publishing via MQTT after data is marked ready
- Updated Makefile and REST endpoints accordingly

Also added:
- Support for runtime shutdown via Ctrl+C
- New utility modules: mqtt_queue.c, file_write.c
- Startup helper: start.sh